### PR TITLE
allow connection to Upstart in absence of system bus

### DIFF
--- a/upstart/job.py
+++ b/upstart/job.py
@@ -2,36 +2,39 @@ import dbus
 
 
 class UpstartJob(object):
-    def __init__(self, job_name):
+    def __init__(self, job_name, bus=None):
         if job_name[0] == '/':
-            raise ValueError("Expected simple, short job name: %s" % 
+            raise ValueError("Expected simple, short job name: %s" %
                              (job_name))
 
-        self.__system = dbus.SystemBus()
+        if bus:
+            self.__system = bus
+        else:
+            self.__system = dbus.SystemBus()
         self.__job_name = job_name
 
         self.__o = self.__system.get_object(
-                'com.ubuntu.Upstart', 
+                'com.ubuntu.Upstart',
                 '/com/ubuntu/Upstart/jobs/%s' % (self.__job_name))
 
         self.__job_i = dbus.Interface(
-                        self.__o, 
+                        self.__o,
                         'com.ubuntu.Upstart0_6.Job')
 
     def get_status(self):
         o = self.__system.get_object(
-                'com.ubuntu.Upstart', 
+                'com.ubuntu.Upstart',
                 '/com/ubuntu/Upstart/jobs/%s/_' % (self.__job_name))
 
         properties_i = dbus.Interface(
-                        o, 
+                        o,
                         'org.freedesktop.DBus.Properties')
 
         return properties_i.GetAll('')
 
     def __get_conditions(self, type_):
         properties_i = dbus.Interface(
-                        self.__o, 
+                        self.__o,
                         'org.freedesktop.DBus.Properties')
 
         return properties_i.Get('com.ubuntu.Upstart0_6.Job', type_)

--- a/upstart/system.py
+++ b/upstart/system.py
@@ -4,24 +4,25 @@ import dbus.connection
 import weakref
 
 
-class DirectBusConnection(dbus.bus.BusConnection):
+class DirectUpstartBus(dbus.bus.BusConnection):
     '''
     dbus_bus_register() fails for direct address connections,
     so we avoid that by creating a connection directly
     '''
-    def __new__(self, address):
-        bus = dbus.connection.Connection(address)
+    def __new__(self):
+        bus = dbus.connection.Connection('unix:abstract=/com/ubuntu/upstart')
         bus._bus_names = weakref.WeakValueDictionary()
         bus._signal_sender_matches = {}
         return bus
 
 
 class UpstartSystem(object):
-    def __init__(self, direct=False):
-        if direct:
-            self.__system = DirectBusConnection('unix:abstract=/com/ubuntu/upstart')
+    def __init__(self, bus=None):
+        if bus:
+            self.__system = bus
         else:
             self.__system = dbus.SystemBus()
+
         self.__o = self.__system.get_object(
                     'com.ubuntu.Upstart',
                     '/com/ubuntu/Upstart')


### PR DESCRIPTION
Minimal CentOS 6 installations don't exhibit system bus socket, but we can connect through Upstart's private dbus socket.
P.S. could you please make a new PyPI release of this?
